### PR TITLE
feat: add ability to mark a card

### DIFF
--- a/internal/files.go
+++ b/internal/files.go
@@ -163,7 +163,11 @@ func (s *Session) updateCardInFile(c *Card) {
 	check(err)
 	md := string(data)
 	re := regexp.MustCompile(fmt.Sprintf(`<!--\s*%s;\d;\d{4}-\d{2}-\d{2}\s*-->`, c.Id))
-	md = re.ReplaceAllString(md, fmt.Sprintf("<!--%s;%d;%s-->", c.Id, c.Box, c.Due.Format("2006-01-02")))
+	markString := ""
+	if c.Marked {
+		markString = ";fixme"
+	}
+	md = re.ReplaceAllString(md, fmt.Sprintf("<!--%s;%d;%s%s-->", c.Id, c.Box, c.Due.Format("2006-01-02"), markString))
 	err = os.WriteFile(s.File.Path, []byte(md), 0644)
 	check(err)
 }
@@ -193,7 +197,7 @@ func (s *Session) ChooseCategory() {
 	}
 
 	fmt.Print("Your choice: ")
-	choice := ReadNumberInput(1, len(categories))
+	choice, _ := ReadNumberInput(1, len(categories))
 	s.Category = categories[choice-1]
 }
 

--- a/internal/leitner.go
+++ b/internal/leitner.go
@@ -199,8 +199,8 @@ func (s *Session) flashNextCard() (c *Card, difficulty float32, marked bool) {
 	back := WrapLines(c.Back, s.WrapLines)
 	fmt.Printf("\n%s\n", back)
 
-	fmt.Println("--> How difficult was it to remember?")
 	fmt.Println("--> Press (m) to mark for later review.")
+	fmt.Println("--> How difficult was it to remember?")
 	fmt.Printf("--> (1) Not remembered, (2) Hard, (3) Okay, (4) Easy: ")
 	d, marked := ReadNumberInput(1, 4)
 	switch d {

--- a/internal/leitner.go
+++ b/internal/leitner.go
@@ -199,7 +199,7 @@ func (s *Session) flashNextCard() (c *Card, difficulty float32, marked bool) {
 	back := WrapLines(c.Back, s.WrapLines)
 	fmt.Printf("\n%s\n", back)
 
-	fmt.Println("--> Press (m) to mark card with 'fixme' tag.")
+	fmt.Println("--> Enter (m) to mark card with 'fixme' tag.")
 	fmt.Println("--> How difficult was it to remember?")
 	fmt.Printf("--> (1) Not remembered, (2) Hard, (3) Okay, (4) Easy: ")
 	d, marked := ReadNumberInput(1, 4)

--- a/internal/leitner.go
+++ b/internal/leitner.go
@@ -199,7 +199,7 @@ func (s *Session) flashNextCard() (c *Card, difficulty float32, marked bool) {
 	back := WrapLines(c.Back, s.WrapLines)
 	fmt.Printf("\n%s\n", back)
 
-	fmt.Println("--> Press (m) to mark for later review.")
+	fmt.Println("--> Press (m) to mark card with 'fixme' tag.")
 	fmt.Println("--> How difficult was it to remember?")
 	fmt.Printf("--> (1) Not remembered, (2) Hard, (3) Okay, (4) Easy: ")
 	d, marked := ReadNumberInput(1, 4)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -43,21 +43,27 @@ func PrintJSON[T any](v T) {
 	fmt.Println(string(out))
 }
 
-// ReadNumberInput reads a number from standard input. The number must be within i and j. If it is not, it will retry.
-func ReadNumberInput(i, j int) int {
-	res := i - 1
+// ReadNumberInput reads a number or "m" symbol from standard input.
+// The number must be within i and j. If it is not, it will retry.
+func ReadNumberInput(i, j int) (int, bool) {
+	marked := false
 	scanner := bufio.NewScanner(os.Stdin)
-	for res < i || res > j {
+
+	for {
 		scanner.Scan()
 		in := scanner.Text()
+		if in == "m" {
+			marked = true
+			fmt.Print("Card marked for edit. Please enter a number: ")
+			continue
+		}
 		nr, err := strconv.Atoi(in)
 		if err != nil || nr < i || nr > j {
 			fmt.Print("Please enter a number: ")
 			continue
 		}
-		res = nr
+		return nr, marked
 	}
-	return res
 }
 
 // ReadEnterInput Blocks until the user enters a newline.

--- a/test.md
+++ b/test.md
@@ -2,12 +2,12 @@
  
 some text that won't be parsed
  
-## Why do broadcast algorithms differentiate between receiving and delivering? Some more text here to test the width setting and line wraps.
+## Why do broadcast algorithms differentiate between receiving and delivering? Some more text here to test the width setting and line wraps. <!--H07U;0;2025-12-17-->
 Because between the network and the application there lies the broadcast algorithm as a middleware. The algorithm decides, whether a message which the node received is forwarded (i.e. delivered) to the application.
 
 The same applies to the send. An application only sees the broadcast call but the middleware then spreads it into multiple point-to-point messages.
 
-## Which types of reliable broadcast are there?
+## Which types of reliable broadcast are there? <!--Ren2;1;2025-12-18-->
 
 - FIFO broadcast
 - Causal broadcast
@@ -18,7 +18,7 @@ The same applies to the send. An application only sees the broadcast call but th
 
 A1
 
-## Q2  <!-- YKuO;0;2023-02-24-->
+## Q2 <!--oCH3;0;2025-12-17-->
 
 A2
 ##   Q3   <!--0YK7;2;2023-02-26  -->
@@ -27,7 +27,7 @@ A3
 # T2
 some other text
 
-## Q4 <!--fjJd;0;2023-02-24-->
+## Q4 <!--fjJd;0;2025-12-17-->
 
 A4
 


### PR DESCRIPTION
I've added a possibility to send "m" in addition to (1,2,3,4) so the card being marked with "fixme". One can search through file and fix it when training session is over.
While reviewing I noticed that the mark is not being preserved so on the next run if "m" wasn't sent it will be missing. I'm not sure if it's good or bad...